### PR TITLE
Meta commands

### DIFF
--- a/command.js
+++ b/command.js
@@ -13,7 +13,7 @@ class Command {
 
 	check(message) {
 		if ((message.content+" ").startsWith('!'+this.command + " ")) {
-			var args = message.content.slice(1+this.command.length);
+			var args = message.content.slice(2+this.command.length);
 			this.respond(message,this.operation(args,message));
 		}
 	}

--- a/command.js
+++ b/command.js
@@ -12,7 +12,7 @@ class Command {
 	}
 
 	check(message) {
-		if (message.content.startsWith('!'+this.command)) {
+		if ((message.content+" ").startsWith('!'+this.command + " ")) {
 			var args = message.content.slice(1+this.command.length);
 			this.respond(message,this.operation(args,message));
 		}

--- a/command.js
+++ b/command.js
@@ -12,7 +12,7 @@ class Command {
 	}
 
 	check(message) {
-		if (message.content.indexOf('!'+this.command) === 0) {
+		if (message.content.startsWith('!'+this.command)) {
 			var args = message.content.slice(1+this.command.length);
 			this.respond(message,this.operation(args,message));
 		}
@@ -33,7 +33,7 @@ class SayCommand extends Command {
 //Command triggered by a substring anywhere in a message
 class Trigger extends SayCommand {
 	check(message) {
-		if (message.content.indexOf('command') !== -1) {
+		if (message.content.includes('command')) {
 			this.respond(message,this.operation());
 		}
 	}
@@ -42,7 +42,7 @@ class Trigger extends SayCommand {
 //Command that does not automatically print reply (useful for e.g. quit command)
 class SilentCommand extends Command {
 	check(message) {
-		if (message.content.indexOf('!'+this.command) === 0) {
+		if (message.content.startsWith('!'+this.command)) {
 			var args = message.content.slice(1+this.command.length);
 			this.operation(args,message);
 		}

--- a/modules/meta.js
+++ b/modules/meta.js
@@ -32,9 +32,13 @@ function repeat(args,message) {
 			reply += ">" + repeatedInstruction + "\n";
 			reply += repeatedCommand.operation(repeatedCommandArgs,message) + "\n";
 		}
+		return reply;
+	}
+	else {
+		return `I'm sorry, I don't recognise the command ${repeatedInstruction}, so I can't repeat it!`;
 	}
 
-	return reply;
+	
 }
 
 function addCommand(args,message) {
@@ -55,7 +59,7 @@ function addCommand(args,message) {
 	}
 
 	if (commandAlreadyExists) {
-		return "Sorry, but there's already a command by that name! Try calling it something else.";
+		return `Sorry, but there's already a command called ${newCommand}! Try calling it something else.`;
 	}
 	else {
 		Bot.commands.push(
@@ -96,7 +100,7 @@ function deleteCommand(args) {
 		}
 		else {
 			Bot.commands.splice(ind,1);
-			return `I've forgotten the command ${commandToDelete}. Hope it wasn't important!`
+			return `OK, I've forgotten the command ${commandToDelete}. Hope it wasn't important!`
 		}
 	}
 }

--- a/modules/meta.js
+++ b/modules/meta.js
@@ -107,7 +107,7 @@ function deleteCommand(args) {
 
 commands.push(
 	new Command.Command(
-		"repeat ",
+		"repeat",
 		"Repeat a command multiple times. Syntax: '!repeat <number> <command> <arguments>' e.g. '!repeat 6 roll 4d6b3'",
 		repeat
 	)
@@ -115,7 +115,7 @@ commands.push(
 
 commands.push(
 	new Command.Command(
-		"newcommand ",
+		"newcommand",
 		"Add a simple, temporary command that returns a message when called. Syntax: !addcommand <command> <message>. Does not persist through bot shutdown!",
 		addCommand
 	)
@@ -123,7 +123,7 @@ commands.push(
 
 commands.push(
 	new Command.Command(
-		"deletecommand ",
+		"deletecommand",
 		"Remove a command. Syntax: !deletecommand <command>. Does not persist through bot shutdown. Still, be careful!",
 		deleteCommand
 	)

--- a/modules/meta.js
+++ b/modules/meta.js
@@ -1,0 +1,51 @@
+//Commands which act on other commands
+
+const Command = require("../command");
+const Bot = require("../bot");
+
+commands = [];
+
+function repeat(args,message) {
+	var iterations = parseInt(args.split(' ',1),10);
+	var repeatedInstruction = args.slice(args.indexOf(' ')+1);
+	var reply = `OK, I'm running '${repeatedInstruction}' ${iterations} times.\n`
+
+	// if the user has written !command instead of just command, remove the !
+	if (repeatedInstruction.startsWith('!')) {
+		repeatedInstruction = repeatedInstruction.slice(1);
+	}
+
+	var repeatedCommand = false;
+
+	//identify the command to be repeated
+	for (command of Bot.commands) {
+		if (repeatedInstruction.startsWith(command.command)) {
+			repeatedCommand = command;
+			break;
+		}
+	}
+
+	//if a command has been identified, execute it N times and append the results to message
+	if (repeatedCommand) {
+		var repeatedCommandArgs = repeatedInstruction.slice(repeatedCommand.command.length);
+		for (var i = 0; i<iterations; i++) {
+			reply += ">" + repeatedInstruction + "\n";
+			reply += repeatedCommand.operation(repeatedCommandArgs,message) + "\n";
+		}
+	}
+
+	return reply;
+}
+
+commands.push(
+	new Command.Command(
+		"repeat ",
+		"Repeat a command multiple times. Syntax: '!repeat <number> <command> <arguments>' e.g. '!repeat 6 roll 4d6b3'",
+		repeat
+	)
+)
+
+module.exports = {
+	name: "Meta",
+	commands: commands
+}

--- a/modules/meta.js
+++ b/modules/meta.js
@@ -8,7 +8,6 @@ commands = [];
 function repeat(args,message) {
 	var iterations = parseInt(args.split(' ',1),10);
 	var repeatedInstruction = args.slice(args.indexOf(' ')+1);
-	var reply = `OK, I'm running '${repeatedInstruction}' ${iterations} times.\n`
 
 	// if the user has written !command instead of just command, remove the !
 	if (repeatedInstruction.startsWith('!')) {
@@ -27,6 +26,7 @@ function repeat(args,message) {
 
 	//if a command has been identified, execute it N times and append the results to message
 	if (repeatedCommand) {
+		var reply = `OK, I'm running '${repeatedInstruction}' ${iterations} times.\n`
 		var repeatedCommandArgs = repeatedInstruction.slice(repeatedCommand.command.length);
 		for (var i = 0; i<iterations; i++) {
 			reply += ">" + repeatedInstruction + "\n";
@@ -37,11 +37,49 @@ function repeat(args,message) {
 	return reply;
 }
 
+function addCommand(args,message) {
+	var newCommand = args.split(' ',1);
+	var newCommandMessage = args.slice(args.indexOf(' ')+1);
+
+	var commandAlreadyExists = false;
+
+	for (command of Bot.commands) {
+		if (command.command.startsWith(newCommand)) {
+			commandAlreadyExists = true;
+		}
+	};
+
+	if (commandAlreadyExists) {
+		return "Sorry, but there's already a command by that name! Try calling it something else.";
+	}
+	else {
+		Bot.commands.push(
+			new Command.Command(
+				newCommand,
+				"Temporary command added by " + message.guild.member(message.author),
+				function () {
+					return newCommandMessage;
+				}
+			)
+		);
+
+		return "OK, when someone says !" + newCommand + ", I will say '" + newCommandMessage + "'!";
+	}
+}
+
 commands.push(
 	new Command.Command(
 		"repeat ",
 		"Repeat a command multiple times. Syntax: '!repeat <number> <command> <arguments>' e.g. '!repeat 6 roll 4d6b3'",
 		repeat
+	)
+)
+
+commands.push(
+	new Command.Command(
+		"newcommand ",
+		"Add a simple, temporary command that returns a message when called. Syntax: !addcommand <command> <message>. Does not persist through bot shutdown!",
+		addCommand
 	)
 )
 

--- a/modules/meta.js
+++ b/modules/meta.js
@@ -44,10 +44,15 @@ function addCommand(args,message) {
 	var commandAlreadyExists = false;
 
 	for (command of Bot.commands) {
-		if (command.command.startsWith(newCommand)) {
-			commandAlreadyExists = true;
+		var commandCall = command.command;
+		if (commandCall.endsWith(' ')) {
+			commandCall = commandCall.slice(0,-1);
 		}
-	};
+		if (commandCall === newCommand) {
+			commandAlreadyExists = true;
+			break;
+		}
+	}
 
 	if (commandAlreadyExists) {
 		return "Sorry, but there's already a command by that name! Try calling it something else.";
@@ -56,7 +61,7 @@ function addCommand(args,message) {
 		Bot.commands.push(
 			new Command.Command(
 				newCommand,
-				"Temporary command added by " + message.guild.member(message.author),
+				"Temporary command added by " + message.author,
 				function () {
 					return newCommandMessage;
 				}
@@ -77,7 +82,11 @@ function deleteCommand(args) {
 	else {
 		var ind = null;
 		Bot.commands.forEach(function(command,commandInd) {
-			if (command.command.startsWith(commandToDelete)) {
+			commandCall = command.command;
+			if (commandCall.endsWith(' ')) {
+				commandCall = commandCall.slice(0,-1);
+			}
+			if (commandToDelete === commandCall) {
 				ind = commandInd;
 			}
 		})

--- a/modules/meta.js
+++ b/modules/meta.js
@@ -38,7 +38,7 @@ function repeat(args,message) {
 }
 
 function addCommand(args,message) {
-	var newCommand = args.split(' ',1);
+	var newCommand = args.split(' ',1)[0];
 	var newCommandMessage = args.slice(args.indexOf(' ')+1);
 
 	var commandAlreadyExists = false;
@@ -75,7 +75,7 @@ function addCommand(args,message) {
 function deleteCommand(args) {
 	var protectedCommands = ['help','quit'];
 
-	var commandToDelete = args.split(' ',1);
+	var commandToDelete = args.split(' ',1)[0];
 	if (protectedCommands.includes(commandToDelete)) {
 		return `Sorry, I can't delete ${commandToDelete} as it is a protected command.`
 	}

--- a/modules/meta.js
+++ b/modules/meta.js
@@ -63,7 +63,32 @@ function addCommand(args,message) {
 			)
 		);
 
-		return "OK, when someone says !" + newCommand + ", I will say '" + newCommandMessage + "'!";
+		return `OK, when someone says !${newCommand}, I will say '${newCommandMessage}'!`;
+	}
+}
+
+function deleteCommand(args) {
+	var protectedCommands = ['help','quit'];
+
+	var commandToDelete = args.split(' ',1);
+	if (protectedCommands.includes(commandToDelete)) {
+		return `Sorry, I can't delete ${commandToDelete} as it is a protected command.`
+	}
+	else {
+		var ind = null;
+		Bot.commands.forEach(function(command,commandInd) {
+			if (command.command.startsWith(commandToDelete)) {
+				ind = commandInd;
+			}
+		})
+
+		if (ind === null) {
+			return `Sorry, ${commandToDelete} does not seem to exist, so I can't delete it!`
+		}
+		else {
+			Bot.commands.splice(ind,1);
+			return `I've forgotten the command ${commandToDelete}. Hope it wasn't important!`
+		}
 	}
 }
 
@@ -80,6 +105,14 @@ commands.push(
 		"newcommand ",
 		"Add a simple, temporary command that returns a message when called. Syntax: !addcommand <command> <message>. Does not persist through bot shutdown!",
 		addCommand
+	)
+)
+
+commands.push(
+	new Command.Command(
+		"deletecommand ",
+		"Remove a command. Syntax: !deletecommand <command>. Does not persist through bot shutdown. Still, be careful!",
+		deleteCommand
 	)
 )
 

--- a/modules/utility.js
+++ b/modules/utility.js
@@ -16,7 +16,7 @@ commands.push(new Command.SilentCommand(
 )
 
 commands.push(new Command.Command(
-	'nickname ',
+	'nickname',
 	"Change my nickname in this server.",
 	function(nickname,message) {
 		message.guild.member(Bot.bot.user).setNickname(nickname);


### PR DESCRIPTION
Adds a new module allowing commands which act on the command list:
- 'repeat', which runs another command multiple times, concatenates the results, and prints it as one message
- 'newcommand', which creates a simple command which makes the bot say a static string when called.
- 'deletecommand', which deletes one of the bot's commands. (Possibly may want to set up a permissions system on this.)
